### PR TITLE
Trying to handle camera initialization errors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,4 +16,3 @@ VideoIO = "d6d074c3-1acf-5d4c-9a43-ef38773959a2"
 [compat]
 VideoIO = "≥ 0.6.2"
 julia = "≥ 1.0.0"
-

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # SpinnakerGUI
 
-A `CImGui.jl`-based GUI for controlling FLIR/PointGrey cameras through the Spinnaker API via `Spinnaker.jl`
+A `CImGui.jl`-based GUI for controlling FLIR/PointGrey cameras through the Spinnaker API via [Spinnaker.jl](https://github.com/samuelpowell/Spinnaker.jl)
 
 Install
 ```
-] add https://github.com/ianshmean/SpinnakerGUI.jl
+] add SpinnakerGUI
 ```
 
 Run

--- a/src/SpinnakerGUI.jl
+++ b/src/SpinnakerGUI.jl
@@ -72,17 +72,19 @@ function start(;camid::Int64=0)
         wait(governorTimer)
     end
     
-    if istaskdone(t_gui) && !istaskdone(t_settings) && !istaskdone(t_recorder) && !istaskdone(t_capture)
+    if !gui_open && istaskdone(t_gui) && !istaskdone(t_settings) && !istaskdone(t_recorder) && !istaskdone(t_capture)
         # if the gui finished, and nothing else finished
         sessionStat.terminate = true #send terminate bool to async functions
         
         while !istaskdone(t_gui) || !istaskdone(t_settings) || !istaskdone(t_recorder) || !istaskdone(t_capture)
             wait(Timer(0.1))
-        end    
+        end
         @info "SpinnakerGUI: Successful exit"
     else
+        println("") #Async errors cause a lack of new line
         @info "SpinnakerGUI: Something went wrong:"
         
+        istaskdone(t_gui) && @info "GUI crashed"
         istaskdone(t_settings) && @info "Camera settings updater crashed"
         istaskdone(t_recorder) && @info "Record listener crashed"
         istaskdone(t_capture) && @info "Camera acquisition crashed"

--- a/src/SpinnakerGUI.jl
+++ b/src/SpinnakerGUI.jl
@@ -6,6 +6,7 @@ Base.@kwdef mutable struct sessionStatus
     savedframes::Int64 = 0
     terminate::Bool = false
     droppedframes::Int64 = 0
+    resolutionupdate::Bool = true
 end
 
 include("utils.jl")

--- a/src/camera-settings.jl
+++ b/src/camera-settings.jl
@@ -180,6 +180,7 @@ function camSettingsUpdater(;timerInterval::AbstractFloat=1/10)
                     lastCamSettings.width = camSettings.width
                     lastCamSettings.height = camSettings.height
                     camSettingsLimitsRead!(cam,camSettingsLimits)
+                    sessionStat.resolutionupdate = true
                 catch e
                     @info "Selected width or height not allowed"
                     camSettings.width = lastCamSettings.width

--- a/src/camera-settings.jl
+++ b/src/camera-settings.jl
@@ -113,7 +113,7 @@ function camSettingsUpdater(;timerInterval::AbstractFloat=1/10)
         if isrunning(cam)
 
             # RECORDING
-            
+
             # FRAMERATE
             if (camSettings.acquisitionFramerate != lastCamSettings.acquisitionFramerate)
                 framerate!(cam,camSettings.acquisitionFramerate)
@@ -167,7 +167,7 @@ function camSettingsUpdater(;timerInterval::AbstractFloat=1/10)
                     lastCamSettings.offsetX = camSettings.offsetX
                     lastCamSettings.offsetY = camSettings.offsetY
                 catch e
-                    @info "Selected x or y offset not allowed"
+                    #@info "Selected x or y offset not allowed"
                     camSettings.offsetX = lastCamSettings.offsetX
                     camSettings.offsetY = lastCamSettings.offsetY
                 end
@@ -182,7 +182,7 @@ function camSettingsUpdater(;timerInterval::AbstractFloat=1/10)
                     camSettingsLimitsRead!(cam,camSettingsLimits)
                     sessionStat.resolutionupdate = true
                 catch e
-                    @info "Selected width or height not allowed"
+                    #@info "Selected width or height not allowed"
                     camSettings.width = lastCamSettings.width
                     camSettings.height = lastCamSettings.height
                 end

--- a/src/camera-spinnaker.jl
+++ b/src/camera-spinnaker.jl
@@ -51,8 +51,7 @@ function startcheckrunningfix!(cam;bufferMode="NewestOnly",maxattempts=5)
         @info "Camera started"
     else
         reinitcam(bufferMode=bufferMode,maxattempts=maxattempts)
-    end
-          
+    end        
 end
 
 function reinitcam(;bufferMode="NewestOnly",maxattempts=5)

--- a/src/camera-spinnaker.jl
+++ b/src/camera-spinnaker.jl
@@ -11,6 +11,9 @@ function cam_init(;camid::Int64=0,silent=false,bufferMode="NewestOnly")
     else
         !silent && (@info "Selecting camera $camid")
         cam = camlist[camid]
+        !silent && (@info "Switching to continuous mode")
+        acquisitionmode!(cam,"Continuous")
+        triggermode!(cam,"Off")
         !silent && (@info "Reading settings from camera")
         camSettingsRead!(cam,camSettings)
         camSettingsLimitsRead!(cam,camSettingsLimits)

--- a/src/camera-spinnaker.jl
+++ b/src/camera-spinnaker.jl
@@ -42,16 +42,16 @@ This function exists because of instability experienced with the Grasshopper 3.
 
 """
 function startcheckrunningfix!(cam;bufferMode="NewestOnly",maxattempts=5)
-    try 
+    try
         start!(cam)
     catch e
         reinitcam(bufferMode=bufferMode,maxattempts=maxattempts)
-    end  
-    if canGetImage(cam) 
+    end
+    if canGetImage(cam)
         @info "Camera started"
     else
         reinitcam(bufferMode=bufferMode,maxattempts=maxattempts)
-    end        
+    end
 end
 
 function reinitcam(;bufferMode="NewestOnly",maxattempts=5)
@@ -70,7 +70,7 @@ function reinitcam(;bufferMode="NewestOnly",maxattempts=5)
         @info "Camera reinitialized"
     end
 end
-    
+
 
 function runCamera()
     global perfGrabFramerate

--- a/src/camera-spinnaker.jl
+++ b/src/camera-spinnaker.jl
@@ -84,11 +84,12 @@ function runCamera()
 
     perfGrabTime = time()
     grabNotRunningTimer = Timer(0.0,interval=1/5)
-    firstframe = true
     while !sessionStat.terminate
         if isrunning(cam)
-            firstframe && (camImage = Array{UInt8}(undef,camSettings.width,camSettings.height))
-            firstframe = false
+            if sessionStat.resolutionupdate
+                camImage = Array{UInt8}(undef,camSettings.width,camSettings.height)
+                sessionStat.resolutionupdate = false
+            end
             try
                 cim_id, cim_timestamp, cim_exposure = getimage!(cam,camImage,normalize=false,timeout=0)
                 if sessionStat.recording
@@ -111,7 +112,6 @@ function runCamera()
             end
             yield()
         else
-            firstframe = true
             wait(grabNotRunningTimer)
             #println("Not running")
         end

--- a/src/gui/gui_control.jl
+++ b/src/gui/gui_control.jl
@@ -204,16 +204,12 @@ function ShowControlWindow(p_open::Ref{Bool})
         if sessionStat.recording
             if CImGui.Button("Stop Recording",(200,25)) 
                 sessionStat.recording = false
-                #stop!(cam)
-                #buffermode!(cam,"NewestOnly")
-                #startcheckrunningfix!(cam,bufferMode="OldestFirst")
+                buffermode!(cam,"NewestOnly")
             end
         else
             if CImGui.Button("Record",(200,25))
                 sessionStat.recording = true
-                #stop!(cam)
-                #buffermode!(cam,"OldestFirst")
-                #startcheckrunningfix!(cam,bufferMode="OldestFirst")
+                buffermode!(cam,"OldestFirst")
             end
         end
         CImGui.SameLine()

--- a/src/gui/gui_control.jl
+++ b/src/gui/gui_control.jl
@@ -193,16 +193,21 @@ function ShowControlWindow(p_open::Ref{Bool})
     ## PLAY/PAUSE
     @cstatic begin
         if camIsRunning
-            CImGui.Button("Pause",(200,25)) && stop!(cam)
+            if CImGui.Button("Pause",(200,25))
+                stop!(cam)
+                @info "Camera stopped"
+            end
         else
-            CImGui.Button("Run",(200,25)) && startcheckrunningfix!(cam)
+            if CImGui.Button("Run",(200,25))
+                startcheckrunningfix!(cam)
+            end
         end
     end
 
     ## RECORDING
     @cstatic begin
         if sessionStat.recording
-            if CImGui.Button("Stop Recording",(200,25)) 
+            if CImGui.Button("Stop Recording",(200,25))
                 sessionStat.recording = false
                 buffermode!(cam,"NewestOnly")
             end

--- a/src/gui/gui_control.jl
+++ b/src/gui/gui_control.jl
@@ -195,7 +195,7 @@ function ShowControlWindow(p_open::Ref{Bool})
         if camIsRunning
             CImGui.Button("Pause",(200,25)) && stop!(cam)
         else
-            CImGui.Button("Run",(200,25)) && startcheckrunningfix!()
+            CImGui.Button("Run",(200,25)) && startcheckrunningfix!(cam)
         end
     end
 
@@ -206,14 +206,14 @@ function ShowControlWindow(p_open::Ref{Bool})
                 sessionStat.recording = false
                 #stop!(cam)
                 #buffermode!(cam,"NewestOnly")
-                #startcheckrunningfix!(bufferMode="OldestFirst")
+                #startcheckrunningfix!(cam,bufferMode="OldestFirst")
             end
         else
             if CImGui.Button("Record",(200,25))
                 sessionStat.recording = true
                 #stop!(cam)
                 #buffermode!(cam,"OldestFirst")
-                #startcheckrunningfix!(bufferMode="OldestFirst")
+                #startcheckrunningfix!(cam,bufferMode="OldestFirst")
             end
         end
         CImGui.SameLine()

--- a/src/recording.jl
+++ b/src/recording.jl
@@ -9,9 +9,9 @@ Based on https://discourse.julialang.org/t/creating-a-video-from-a-stack-of-imag
 Reference for H.264: https://trac.ffmpeg.org/wiki/Encode/H.264#LosslessH.264
 The range of the compression (CRF) scale is 0–51, where 0 is lossless, 23 is the default, and 51 is worst quality possible
 ```
-function videowritelistener(;compression=0,overwrite=false, options=``)
+function videowritelistener(;compression=0,overwrite=false, options="",threads=0)
 
-    ow = overwrite ? `-y` : `-n`
+    ow = overwrite ? "-y" : "-n"
     preset = (compression == 0) ? "ultrafast" : "medium"
 
     global sessionStat
@@ -32,7 +32,7 @@ function videowritelistener(;compression=0,overwrite=false, options=``)
                 "DYLD_LIBRARY_PATH" => VideoIO.libpath) do
                 open(`$(VideoIO.ffmpeg)
                     -loglevel warning
-                    -threads 2
+                    -threads $threads
                     $ow -f rawvideo -pix_fmt gray -s:v $(h)x$(w)
                     -r $fps -i pipe:0 -c:v libx264 -preset: $preset
                     -crf $compression -pix_fmt yuv422p $options

--- a/src/recording.jl
+++ b/src/recording.jl
@@ -9,9 +9,9 @@ Based on https://discourse.julialang.org/t/creating-a-video-from-a-stack-of-imag
 Reference for H.264: https://trac.ffmpeg.org/wiki/Encode/H.264#LosslessH.264
 The range of the compression (CRF) scale is 0–51, where 0 is lossless, 23 is the default, and 51 is worst quality possible
 ```
-function videowritelistener(;compression=0,overwrite=false, options="",threads=0)
+function videowritelistener(;compression=0,overwrite=false,threads=0)
 
-    ow = overwrite ? "-y" : "-n"
+    ow = overwrite ? `-y` : `-n`
     preset = (compression == 0) ? "ultrafast" : "medium"
 
     global sessionStat
@@ -23,34 +23,37 @@ function videowritelistener(;compression=0,overwrite=false, options="",threads=0
             fname = string(Dates.format(now(), "yyyy-mm-dd_HHMMSS"),".mp4")
             h, w = size(camImageFrameBuffer[1])
             if (h % 2 != 0) || (w % 2 != 0)
-                # enable padding if either dim is odd, given H264 requires even
-                options = string(options,""" -vf \"transpose=0,pad=ceil($(w)/2)*2:ceil($(h)/2)*2\" """)
-            end
-            fps = camSettings.acquisitionFramerate
-            withenv("PATH" => VideoIO.libpath, 
-                "LD_LIBRARY_PATH" => VideoIO.libpath, 
-                "DYLD_LIBRARY_PATH" => VideoIO.libpath) do
-                open(`$(VideoIO.ffmpeg)
-                    -loglevel warning
-                    -threads $threads
-                    $ow -f rawvideo -pix_fmt gray -s:v $(h)x$(w)
-                    -r $fps -i pipe:0 -c:v libx264 -preset: $preset
-                    -crf $compression -pix_fmt yuv422p $options
-                    $fname`, "w") do out
-                    while (length(camImageFrameBuffer) > 0 || sessionStat.recording) && !sessionStat.terminate
-                        while length(camImageFrameBuffer) == 0 && sessionStat.recording
-                            wait(Timer(0.01)) #wait without blocking during recording time
+                @info "Image dims for H264 video encoding need to be even ($h x $w)"
+                sessionStat.recording = false
+                camImageFrameBuffer = Vector{Array{UInt8}}(undef,0)
+                sessionStat.bufferedframes = 0
+            else
+                fps = camSettings.acquisitionFramerate
+                withenv("PATH" => VideoIO.libpath,
+                    "LD_LIBRARY_PATH" => VideoIO.libpath,
+                    "DYLD_LIBRARY_PATH" => VideoIO.libpath) do
+                    open(`$(VideoIO.ffmpeg)
+                        -loglevel warning
+                        -threads $threads
+                        $ow -f rawvideo -pix_fmt gray -s:v $(h)x$(w)
+                        -r $fps -i pipe:0 -c:v libx264 -preset: $preset
+                        -crf $compression -pix_fmt yuv422p
+                        $fname`, "w") do out
+                        while (length(camImageFrameBuffer) > 0 || sessionStat.recording) && !sessionStat.terminate
+                            while length(camImageFrameBuffer) == 0 && sessionStat.recording
+                                wait(Timer(0.01)) #wait without blocking during recording time
+                            end
+                            if length(camImageFrameBuffer) >0
+                                write(out, camImageFrameBuffer[1])
+                                deleteat!(camImageFrameBuffer, 1)
+                                sessionStat.bufferedframes = length(camImageFrameBuffer)
+                                sessionStat.savedframes += 1
+                            end
+                            yield()
                         end
-                        if length(camImageFrameBuffer) >0
-                            write(out, camImageFrameBuffer[1])
-                            deleteat!(camImageFrameBuffer, 1)
-                            sessionStat.bufferedframes = length(camImageFrameBuffer)
-                            sessionStat.savedframes += 1
-                        end
-                        yield()
+                        filepath = joinpath(pwd(),fname)
+                        @info "Video saved [$(sessionStat.savedframes) frames, $(fps) fps]: $(filepath)"
                     end
-                    filepath = joinpath(pwd(),fname)
-                    @info "Video saved [$(sessionStat.savedframes) frames, $(fps) fps]: $(filepath)"
                 end
             end
         end


### PR DESCRIPTION
I'm having a lot of errors trying to start and stop/start my Grasshopper 3 as mentioned in https://github.com/samuelpowell/Spinnaker.jl/issues/36. I'm sure I'm stressing the issue by testing on an Ubuntu VM, but it would be good to be able to handle initialization errors, so I'm setting that as the bar for success.

@samuelpowell Once we've fixed the `framerate!()` issue for your camera, it would be great if you could try this branch, and see if `@info "Camera Issue: Reinitializing camera"` ever occurs. 

It may be faulty hardware at my end..

About 50% of the times I try to load the gui, or start/stop the camera, either `start!(cam)` errors or the `getimage(cam,timeout=2000)` check times-out, and then the reinitialization hits maxattempts. Sometimes the reinit process does work though. Physically rebooting the camera does seem to help, but it's not 100% effective

```
julia> start()
[ Info: Checking for cameras
[ Info: Selecting camera 0
[ Info: Reading settings from camera
[ Info: Camera ready
[ Info: Starting GUI (async)
[ Info: Starting Camera Settings Updater (async)
[ Info: Starting recording listener (async)
[ Info: Starting Camera Acquisition (async)
[ Info: Camera Issue: Reinitializing camera
┌ Warning: @async error from @async runCamera()
└ @ SpinnakerGUI /media/psf/Home/Documents/Leuko/GitHub/SpinnakerGUI.jl/src/utils.jl:22
Camera couldn't be reinitialized (tried 5 times)
```
