### PR TITLE
image buffer stack bugfix

### DIFF
--- a/src/camera-spinnaker.jl
+++ b/src/camera-spinnaker.jl
@@ -95,7 +95,7 @@ function runCamera()
             try
                 cim_id, cim_timestamp, cim_exposure = getimage!(cam,camImage,normalize=false,timeout=0)
                 if sessionStat.recording
-                    push!(camImageFrameBuffer,camImage)
+                    push!(camImageFrameBuffer,copy(camImage))
                     sessionStat.bufferedframes = length(camImageFrameBuffer)
                     sessionStat.droppedframes = bufferunderrun(cam)
                 end


### PR DESCRIPTION
wasn't copying the camimage, so the buffer stack was pointing to the original, and not frozen frames