### PR TITLE
Set compat bounds for CImGui

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,5 +14,6 @@ Spinnaker = "8e0d2ad3-56b8-53f3-8036-54b674872bef"
 VideoIO = "d6d074c3-1acf-5d4c-9a43-ef38773959a2"
 
 [compat]
+CImGui = "~1.79"
 VideoIO = "≥ 0.6.2"
 julia = "≥ 1.0.0"


### PR DESCRIPTION
CImGui major/minor versions follow upstream ImGui, so minor version updates may be breaking. This only allows patch updates. Going from the age of the repo I'm guessing this is only compatible with 1.79?

(making the PR because there's a new breaking release: https://github.com/Gnimuc/CImGui.jl/releases/tag/v1.89.0)